### PR TITLE
Gitignore: Ignore built citra folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ repo/
 
 # GitHub Actions generated files
 node_modules/
+
+# built citra
+head/
+artifacts/


### PR DESCRIPTION
Hello
In this m1 mac book pro environment, it crashes when trying to start this citra